### PR TITLE
Stop depending on wasm-bindgen and js-sys on non-wasm targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 nalgebra = "0.33"
 approx = "0.5.1"
-wasm-bindgen = "0.2"
 libm = "0.2.8"
 thiserror = "1.0.63"
-js-sys = "0.3.69"
 strum = "0.26.3"
 strum_macros = "0.26.4"
 num-traits = "0.2.19"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3.69"
 
 [features]
 defaults = ["cie-illuminants", "supplemental-observers"]

--- a/src/cam/viewconditions.rs
+++ b/src/cam/viewconditions.rs
@@ -1,6 +1,4 @@
-use wasm_bindgen::prelude::wasm_bindgen;
-
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Debug)]
 pub struct ViewConditions {
     /// Degree of Adaptation, if omitted, formula 4.3 of CIE248:2022 is used.``

--- a/src/colorant/munsell_matt.rs
+++ b/src/colorant/munsell_matt.rs
@@ -11,7 +11,6 @@
 mod data;
 
 use std::{collections::BTreeMap, sync::LazyLock};
-use wasm_bindgen::prelude::*;
 
 use crate::{
     colorant::munsell_matt::data::{MUNSELL_MATT_DATA, MUNSELL_MATT_KEYS},
@@ -24,7 +23,7 @@ pub(crate) const MATT_N: usize = 81;
 pub(crate) const MATT_M: usize = 1269;
 
 #[allow(dead_code)]
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct MunsellMatt(String, Spectrum);
 
 impl MunsellMatt {
@@ -62,11 +61,6 @@ impl MunsellMatt {
         }
     }
 }
-
-// JS-WASM Interface code
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl MunsellMatt {}
 
 pub struct MunsellMattCollection;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-use wasm_bindgen::JsValue;
-
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
     #[error("{name} should be within in range from {low} to {high}")]
@@ -50,13 +48,15 @@ impl From<&str> for Error {
     }
 }
 
-impl From<JsValue> for Error {
-    fn from(s: JsValue) -> Self {
+#[cfg(target_arch = "wasm32")]
+impl From<wasm_bindgen::JsValue> for Error {
+    fn from(s: wasm_bindgen::JsValue) -> Self {
         Error::ErrorString(s.as_string().expect("Sorry, Unknown Error Encountered"))
     }
 }
 
-impl From<Error> for JsValue {
+#[cfg(target_arch = "wasm32")]
+impl From<Error> for wasm_bindgen::JsValue {
     fn from(value: Error) -> Self {
         value.to_string().into()
     }

--- a/src/illuminant/cie_illuminant.rs
+++ b/src/illuminant/cie_illuminant.rs
@@ -2,14 +2,13 @@
 
 use crate::{illuminant::Illuminant, spectrum::Spectrum, traits::Light};
 use std::borrow::Cow;
-use wasm_bindgen::prelude::*;
 
 macro_rules! std_illuminants {
     ($($val:ident)* [$($cieval:ident)* ]) => {
         // only basic selection
         #[cfg(not(feature="cie-illuminants"))]
         #[allow(non_camel_case_types)]
-        #[wasm_bindgen]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
         #[derive(Clone, Copy, Debug, strum_macros::Display, strum_macros::EnumIter)]
         pub enum CieIlluminant  {
                 $($val,)*
@@ -50,7 +49,7 @@ macro_rules! std_illuminants {
         /// }
         /// ```
         #[allow(non_camel_case_types)]
-        #[wasm_bindgen]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
         #[derive(Clone, Debug, Copy, strum_macros::Display, strum_macros::EnumIter)]
         pub enum CieIlluminant  {
                 $($val,)*

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -6,8 +6,6 @@
 
  */
 
-use wasm_bindgen::prelude::*;
-
 use crate::{
     colorant::{N_TCS, TCS},
     error::Error,
@@ -16,7 +14,7 @@ use crate::{
     xyz::XYZ,
 };
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy)]
 /// The **Color Rendering Index (CRI)** for a light source, computed according to CIE 13.3-1995.
 ///
@@ -147,11 +145,6 @@ impl AsRef<[f64]> for CRI {
         &self.0
     }
 }
-
-// JS-WASM Interface code
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl CRI {}
 
 fn cd(uv60: [f64; 2]) -> [f64; 2] {
     let [u, v] = uv60;

--- a/src/illuminant/wasm.rs
+++ b/src/illuminant/wasm.rs
@@ -1,0 +1,42 @@
+//! JS-WASM Interface code
+
+use super::{CieIlluminant, Illuminant};
+use crate::spectrum::Spectrum;
+use crate::traits::Light;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+impl Illuminant {
+    /// Create a new illuminant spectrum from the given data.
+    ///
+    /// The data must be the 401 values from 380 to 780 nm, with an interval size of 1 nanometer.
+    #[wasm_bindgen(constructor)]
+    pub fn new_js(data: &[f64]) -> Result<Illuminant, wasm_bindgen::JsError> {
+        Ok(Illuminant(Spectrum::try_from(data)?))
+    }
+
+    /// Returns the spectral data values, as a Float64Array containing 401 data
+    /// points, over a wavelength domain from 380 t0 780 nanometer, with a
+    /// stepsize of 1 nanometer.
+    #[wasm_bindgen(js_name=Values)]
+    pub fn values_js(&self) -> Box<[f64]> {
+        let values = self.spectrum().values().as_slice().to_vec();
+        values.into_boxed_slice()
+    }
+
+    /// Calculates the Color Rendering Index values for illuminant spectrum.
+    #[cfg(feature = "cri")]
+    #[wasm_bindgen(js_name=cri)]
+    pub fn cri_js(&self) -> Result<crate::illuminant::CRI, crate::Error> {
+        self.cri()
+    }
+
+    /// Get the CieIlluminant spectrum. Typically you don't need to use the Spectrum itself, as many
+    /// methods just accept the CieIlluminant directly.
+    #[wasm_bindgen(js_name=illuminant)]
+    pub fn llluminant_js(stdill: CieIlluminant) -> Self {
+        // need this as wasm_bindgen does not support `impl` on Enum types (yet?).
+        // in Rust use CieIlluminant.spectrum() directly, which also gives a reference instead of a copy.
+        stdill.illuminant().clone()
+    }
+}

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -50,9 +50,8 @@ use nalgebra::Vector3;
 use std::f64::consts::PI;
 
 use crate::{error::Error, prelude::Observer, xyz::XYZ};
-use wasm_bindgen::prelude::wasm_bindgen;
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy)]
 pub struct CieLab {
     pub(crate) observer: Observer,

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -60,7 +60,6 @@ use crate::{
 use nalgebra::{Matrix3, SMatrix, Vector3};
 use std::{ops::RangeInclusive, sync::OnceLock};
 use strum_macros::EnumIter;
-use wasm_bindgen::prelude::wasm_bindgen;
 
 /**
    Light-weight identifier added to the `XYZ` and `RGB` datasets,
@@ -70,7 +69,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
    This can be directly used in JavaScript, and has the benefit to be just an index.
 */
 #[cfg(not(feature = "supplemental-observers"))]
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
 pub enum Observer {
     #[default]
@@ -78,7 +77,7 @@ pub enum Observer {
 }
 
 #[cfg(feature = "supplemental-observers")]
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
 pub enum Observer {
     #[default]
@@ -124,7 +123,7 @@ impl Observer {
     It's main purpose is to calculate `XYZ` tristimulus values for a general stimulus,
     in from of a `Spectrum`.
 */
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct ObserverData {
     data: SMatrix<f64, 3, NS>,
     lumconst: f64,
@@ -487,11 +486,6 @@ impl ObserverData {
         }
     }
 }
-
-// JS-WASM Interface code
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl ObserverData {}
 
 #[cfg(test)]
 mod obs_test {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -72,7 +72,6 @@ use crate::{
 use approx::AbsDiffEq;
 use nalgebra::Vector3;
 use std::borrow::Cow;
-use wasm_bindgen::prelude::wasm_bindgen;
 
 /// Represents a color stimulus using Red, Green, and Blue (RGB) values constrained to the `[0.0, 1.0]` range.
 /// Each component is a floating-point value representing the relative intensity of the respective primary color
@@ -102,7 +101,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 ///   outside this range will result in an error.
 /// - The `observer` field allows for color conversion accuracy under different lighting and viewing conditions,
 ///   enhancing the reliability of transformations to other color spaces such as XYZ.
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rgb {
     /// The RGB color space the color values are using. Often this is the _sRGB_

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -6,7 +6,6 @@ use crate::{
     rgb::gamma::GammaCurve, rgb::gaussian_filtered_primaries, stimulus::Stimulus,
 };
 use strum_macros::EnumIter;
-use wasm_bindgen::prelude::wasm_bindgen;
 
 // The display P3 red coordinate is outside the CIE 1931 gamut using the CIE 1931 1 nanometer
 // dataset as provided by the CIE.  To still match it, it's desatured it adding white. It also mixes
@@ -15,8 +14,8 @@ const D: f64 = 0.0005620; // Desaturation ratio
 const D65X: f64 = 0.312_738;
 const D65Y: f64 = 0.329_052;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Default, EnumIter, PartialEq)]
-#[wasm_bindgen]
 /**
 A Light Weight tag, representing an RGB color space.
 Used for example in the RGB value set, to identify the color space being used.

--- a/src/rgb/widergb.rs
+++ b/src/rgb/widergb.rs
@@ -45,9 +45,8 @@ use crate::{
 };
 use approx::AbsDiffEq;
 use nalgebra::Vector3;
-use wasm_bindgen::prelude::wasm_bindgen;
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Represents a color stimulus using unconstrained Red, Green, and Blue (RGB) floating-point values
 /// within a device's RGB color space. The values can extend beyond the typical 0.0 to 1.0 range,

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -16,14 +16,15 @@ use std::{
 
 use approx::AbsDiffEq;
 
-use wasm_bindgen::prelude::*;
-
 use nalgebra::{DVector, SVector};
 
 use crate::{math::Gaussian, Error};
 
 mod wavelength;
 pub use wavelength::{to_wavelength, wavelength, wavelengths};
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
 
 /// The wavelength range of the spectrums supported by this library.
 ///
@@ -44,7 +45,7 @@ are available in this library, such as standard illuminants A and D65, Planckian
 (Black Body) illuminants, or a `Stimulus` spectrum for a pixel of an sRGB
 display.
  */
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Spectrum(pub(crate) SVector<f64, NS>);
 
@@ -216,79 +217,6 @@ impl AbsDiffEq for Spectrum {
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         self.0.abs_diff_eq(&other.0, epsilon)
-    }
-}
-
-// JS-WASM Interface code
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl Spectrum {
-    /// Creates a new Spectrum object, using as input a `Category`, a
-    /// Float64Array with exactly 401 datapoints, and an optional third
-    /// parameter called total, representing the total irradiance, transmission,
-    /// or reflectivity of the values, depending on the category of the
-    /// spectrum. The spectral values should be associated with a wavelength
-    /// domain from 380 to 480 nanometer, with an interval size of 1 nanometer.
-    ///
-    /// If the Spectral data you have uses another wavelength domain and/or a different
-    /// wavelength interval, use the linear or sprague interpolate constructors,
-    /// which takes a wavelength domain and spectral data as arguments.
-    #[wasm_bindgen(constructor)]
-    pub fn new_js(data: &[f64]) -> Result<Spectrum, wasm_bindgen::JsError> {
-        Ok(Spectrum::try_from(data)?)
-    }
-
-    /// Returns the spectral data values, as a Float64Array containing 401 data
-    /// points, over a wavelength domain from 380 t0 780 nanometer, with a
-    /// stepsize of 1 nanometer.
-    #[wasm_bindgen(js_name=Values)]
-    pub fn values_js(&self) -> Box<[f64]> {
-        let values: &[f64] = self.as_ref();
-        values.into()
-    }
-
-    /// This function maps spectral data with irregular intervals or intervals different than 1
-    /// nanometer to the standard spectrum as used in this library.
-    ///
-    /// For domains with a regular interval, the wavelength slice should have a size of two, containing
-    /// the minimum and maximum wavelength values, both also in units of meters or nanometers.
-    ///
-    /// For irregular domains, this function requires a slice of wavelengths and a slice of spectral
-    /// data, both of the same size. The wavelengths can be specified in units of meters or nanometers.
-    ///
-    /// In case of duplicate wavelength values the last data values is used, so it is impossible to
-    /// define filters with vertical edges using this method.
-    ///
-    /// ```rust
-    /// // Creates a linear gradient filter, with a zero transmission at 380 nanometer, and full
-    /// // transmission at 780 nanometer. This is an example using a uniform wavelength domain as input.
-    /// use colorimetry::prelude::*;
-    /// use approx::assert_ulps_eq;
-    /// let data = [0.0, 1.0];
-    /// let wl = [380.0, 780.0];
-    /// let mut spd = Spectrum::linear_interpolate(&wl, &data).unwrap();
-    /// assert_ulps_eq!(spd[380], 0.);
-    /// assert_ulps_eq!(spd[380+100], 0.25);
-    /// assert_ulps_eq!(spd[380+200], 0.5);
-    /// assert_ulps_eq!(spd[380+300], 0.75);
-    /// assert_ulps_eq!(spd[380+400], 1.0);
-
-    /// // Creates a top hat filter, with slanted angles, using an irregular
-    /// // wavelength domain.
-    /// let data = vec![0.0, 1.0, 1.0, 0.0];
-    /// let wl = vec![480.0, 490.0, 570.0, 580.0];
-    /// let spd = Spectrum::linear_interpolate(&wl, &data).unwrap();
-    /// assert_ulps_eq!(spd[380+0], 0.0);
-    /// assert_ulps_eq!(spd[380+100], 0.0);
-    /// assert_ulps_eq!(spd[380+110], 1.0);
-    /// assert_ulps_eq!(spd[380+190], 1.0);
-    /// assert_ulps_eq!(spd[380+200], 0.0);
-    /// assert_ulps_eq!(spd[380+300], 0.0);
-    /// assert_ulps_eq!(spd[380+400], 0.0);
-    /// ```
-    #[wasm_bindgen(js_name=linearInterpolate)]
-    pub fn linear_interpolate_js(wavelengths: &[f64], data: &[f64]) -> Result<Spectrum, Error> {
-        Self::linear_interpolate(wavelengths, data)
     }
 }
 

--- a/src/spectrum/wasm.rs
+++ b/src/spectrum/wasm.rs
@@ -1,0 +1,75 @@
+//! JS-WASM Interface code
+
+use super::Spectrum;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+impl Spectrum {
+    /// Create a new spectrum from the given data.
+    ///
+    /// The data must be the 401 values from 380 to 780 nm, with an interval size of 1 nanometer.
+    ///
+    /// If the Spectral data you have uses another wavelength domain and/or a different
+    /// wavelength interval, use the linear interpolate constructor,
+    /// which takes a wavelength domain and spectral data as arguments.
+    #[wasm_bindgen(constructor)]
+    pub fn new_js(data: &[f64]) -> Result<Spectrum, wasm_bindgen::JsError> {
+        Ok(Spectrum::try_from(data)?)
+    }
+
+    /// Returns the spectral data values, as a Float64Array containing 401 data
+    /// points, over a wavelength domain from 380 t0 780 nanometer, with a
+    /// stepsize of 1 nanometer.
+    #[wasm_bindgen(js_name=Values)]
+    pub fn values_js(&self) -> Box<[f64]> {
+        let values: &[f64] = self.as_ref();
+        values.into()
+    }
+
+    /// This function maps spectral data with irregular intervals or intervals different than 1
+    /// nanometer to the standard spectrum as used in this library.
+    ///
+    /// For domains with a regular interval, the wavelength slice should have a size of two, containing
+    /// the minimum and maximum wavelength values, both also in units of meters or nanometers.
+    ///
+    /// For irregular domains, this function requires a slice of wavelengths and a slice of spectral
+    /// data, both of the same size. The wavelengths can be specified in units of meters or nanometers.
+    ///
+    /// In case of duplicate wavelength values the last data values is used, so it is impossible to
+    /// define filters with vertical edges using this method.
+    ///
+    /// ```rust
+    /// // Creates a linear gradient filter, with a zero transmission at 380 nanometer, and full
+    /// // transmission at 780 nanometer. This is an example using a uniform wavelength domain as input.
+    /// use colorimetry::prelude::*;
+    /// use approx::assert_ulps_eq;
+    /// let data = [0.0, 1.0];
+    /// let wl = [380.0, 780.0];
+    /// let mut spd = Spectrum::linear_interpolate(&wl, &data).unwrap();
+    /// assert_ulps_eq!(spd[380], 0.);
+    /// assert_ulps_eq!(spd[380+100], 0.25);
+    /// assert_ulps_eq!(spd[380+200], 0.5);
+    /// assert_ulps_eq!(spd[380+300], 0.75);
+    /// assert_ulps_eq!(spd[380+400], 1.0);
+    ///
+    /// // Creates a top hat filter, with slanted angles, using an irregular
+    /// // wavelength domain.
+    /// let data = vec![0.0, 1.0, 1.0, 0.0];
+    /// let wl = vec![480.0, 490.0, 570.0, 580.0];
+    /// let spd = Spectrum::linear_interpolate(&wl, &data).unwrap();
+    /// assert_ulps_eq!(spd[380+0], 0.0);
+    /// assert_ulps_eq!(spd[380+100], 0.0);
+    /// assert_ulps_eq!(spd[380+110], 1.0);
+    /// assert_ulps_eq!(spd[380+190], 1.0);
+    /// assert_ulps_eq!(spd[380+200], 0.0);
+    /// assert_ulps_eq!(spd[380+300], 0.0);
+    /// assert_ulps_eq!(spd[380+400], 0.0);
+    /// ```
+    #[wasm_bindgen(js_name=linearInterpolate)]
+    pub fn linear_interpolate_js(
+        wavelengths: &[f64],
+        data: &[f64],
+    ) -> Result<Spectrum, crate::Error> {
+        Self::linear_interpolate(wavelengths, data)
+    }
+}

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -41,9 +41,11 @@ use core::f64;
 use crate::{error::Error, observer::Observer, rgb::RgbSpace, rgb::WideRgb};
 use approx::AbsDiffEq;
 use nalgebra::{ArrayStorage, Vector3};
-use wasm_bindgen::prelude::wasm_bindgen;
 
-#[wasm_bindgen]
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 /// Represents a color by its tristimulus value XYZ color space.
 ///
@@ -370,109 +372,6 @@ impl std::ops::Add<XYZ> for XYZ {
         );
         self.xyz += rhs.xyz;
         self
-    }
-}
-
-// JS-WASM Interface code
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl XYZ {
-    /**
-    Create an XYZ Tristimuls Values object.
-
-    Accepts as arguments
-
-    - x and y chromaticity coordinates only , using the "Cie::Std1931" observer as default
-    - x and y chromaticity coordinates, and standard observer ID as 3rd argument
-    - X, Y, and Z tristimulus values, using the "Cie::Std1931" observer as default
-    - X, Y, and Z tristimulus values, and a standard Observer ID as 4th argument
-
-    When only x and y chromaticity coordinates are specified, the luminous
-    value is set to 100.0 candela per square meter.
-
-    ```javascript, ignore
-    // Create a new XYZ object using D65 CIE 1931 chromaticity coordinates
-    const xyz = new cmt.XYZ(0.31272, 0.32903);
-
-    // Get and check the corresponding tristimulus values, with a luminous value
-    // of 100.0
-    const [x, y, z] = xyz.values();
-    assert.assertAlmostEquals(x, 95.047, 5E-3); // D65 wikipedia
-    assert.assertAlmostEquals(y, 100.0);
-    assert.assertAlmostEquals(z, 108.883, 5E-3);
-
-    // and get back the orgiinal chromaticity coordinates:
-    const [xc, yc] = xyz.chromaticity();
-    assert.assertAlmostEquals(xc, 0.31272);
-    assert.assertAlmostEquals(yc, 0.32903);
-
-
-    // to get the luminous value:
-    const l = xyz.luminousValue();
-    assert.assertAlmostEquals(l, 100.0);
-    // D65 CIE 1931 chromaticity coordinates
-    const xyz = new cmt.XYZ(0.31272, 0.32903);
-    ```
-    */
-
-    #[wasm_bindgen(constructor, variadic)]
-    pub fn new_js(x: f64, y: f64, opt: &js_sys::Array) -> Result<XYZ, crate::error::Error> {
-        use crate::error::Error;
-        use wasm_bindgen::convert::TryFromJsValue;
-        let (x, y, z, obs) = match opt.length() {
-            0 => (
-                x * 100.0 / y,
-                100.0,
-                (1.0 - x - y) * 100.0 / y,
-                Observer::Std1931,
-            ),
-            1 => {
-                if opt.get(0).as_f64().is_some() {
-                    (x, y, opt.get(0).as_f64().unwrap(), Observer::Std1931)
-                } else {
-                    let obs = Observer::try_from_js_value(opt.get(0))?;
-                    (x * 100.0 / y, 100.0, (1.0 - x - y) * 100.0 / y, obs)
-                }
-            }
-            2 => {
-                let z = opt.get(0).as_f64().ok_or(Error::ErrorString(
-                    "please provide a z value as number".into(),
-                ))?;
-                let obs = Observer::try_from_js_value(opt.get(1))?;
-                (x, y, z, obs)
-            }
-            _ => {
-                return Err(Error::ErrorString(
-                    "Invalid Arguments for XYZ constructor".into(),
-                ));
-            }
-        };
-        if x < 0.0 || y < 0.0 || z < 0.0 {
-            return Err(Error::ErrorString(
-                "XYZ values should be all positive values".into(),
-            ));
-        }
-        Ok(XYZ::from_vecs(Vector3::new(x, y, z), obs))
-    }
-
-    /// Get the XYZ tristimulus value as an array.
-    #[wasm_bindgen(js_name=values)]
-    pub fn values_js(&self) -> js_sys::Array {
-        let &[x, y, z] = self.xyz.as_ref();
-        js_sys::Array::of3(&x.into(), &y.into(), &z.into())
-    }
-
-    /// Get the chromaticity coordinates
-    #[wasm_bindgen(js_name=chromaticity)]
-    pub fn chromaticity_js(&self) -> js_sys::Array {
-        let [x, y] = self.chromaticity().to_array();
-        js_sys::Array::of2(&x.into(), &y.into())
-    }
-
-    /// Get the luminous value, Y.
-    #[wasm_bindgen(js_name=y)]
-    pub fn y_js(&self) -> f64 {
-        self.y()
     }
 }
 

--- a/src/xyz/chromaticity.rs
+++ b/src/xyz/chromaticity.rs
@@ -1,8 +1,7 @@
 use nalgebra::Vector2;
-use wasm_bindgen::prelude::wasm_bindgen;
 
 /// A chromaticity coordinate with x and y values.
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Chromaticity {
     xy: Vector2<f64>,

--- a/src/xyz/wasm.rs
+++ b/src/xyz/wasm.rs
@@ -1,0 +1,103 @@
+//! JS-WASM Interface code
+
+use super::XYZ;
+use crate::observer::Observer;
+use nalgebra::Vector3;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+impl XYZ {
+    /// Create an XYZ Tristimuls Values object.
+    ///
+    /// Accepts as arguments
+    ///
+    /// - x and y chromaticity coordinates only , using the "Cie::Std1931" observer as default
+    /// - x and y chromaticity coordinates, and standard observer ID as 3rd argument
+    /// - X, Y, and Z tristimulus values, using the "Cie::Std1931" observer as default
+    /// - X, Y, and Z tristimulus values, and a standard Observer ID as 4th argument
+    ///
+    /// When only x and y chromaticity coordinates are specified, the luminous
+    /// value is set to 100.0 candela per square meter.
+    ///
+    /// ```javascript, ignore
+    /// // Create a new XYZ object using D65 CIE 1931 chromaticity coordinates
+    /// const xyz = new cmt.XYZ(0.31272, 0.32903);
+    ///
+    /// // Get and check the corresponding tristimulus values, with a luminous value
+    /// // of 100.0
+    /// const [x, y, z] = xyz.values();
+    /// assert.assertAlmostEquals(x, 95.047, 5E-3); // D65 wikipedia
+    /// assert.assertAlmostEquals(y, 100.0);
+    /// assert.assertAlmostEquals(z, 108.883, 5E-3);
+    ///
+    /// // and get back the orgiinal chromaticity coordinates:
+    /// const [xc, yc] = xyz.chromaticity();
+    /// assert.assertAlmostEquals(xc, 0.31272);
+    /// assert.assertAlmostEquals(yc, 0.32903);
+    ///
+    /// // to get the luminous value:
+    /// const l = xyz.luminousValue();
+    /// assert.assertAlmostEquals(l, 100.0);
+    /// // D65 CIE 1931 chromaticity coordinates
+    /// const xyz = new cmt.XYZ(0.31272, 0.32903);
+    /// ```
+    #[wasm_bindgen(constructor, variadic)]
+    pub fn new_js(x: f64, y: f64, opt: &js_sys::Array) -> Result<XYZ, crate::error::Error> {
+        use crate::error::Error;
+        use wasm_bindgen::convert::TryFromJsValue;
+        let (x, y, z, obs) = match opt.length() {
+            0 => (
+                x * 100.0 / y,
+                100.0,
+                (1.0 - x - y) * 100.0 / y,
+                Observer::Std1931,
+            ),
+            1 => {
+                if opt.get(0).as_f64().is_some() {
+                    (x, y, opt.get(0).as_f64().unwrap(), Observer::Std1931)
+                } else {
+                    let obs = Observer::try_from_js_value(opt.get(0))?;
+                    (x * 100.0 / y, 100.0, (1.0 - x - y) * 100.0 / y, obs)
+                }
+            }
+            2 => {
+                let z = opt.get(0).as_f64().ok_or(Error::ErrorString(
+                    "please provide a z value as number".into(),
+                ))?;
+                let obs = Observer::try_from_js_value(opt.get(1))?;
+                (x, y, z, obs)
+            }
+            _ => {
+                return Err(Error::ErrorString(
+                    "Invalid Arguments for XYZ constructor".into(),
+                ));
+            }
+        };
+        if x < 0.0 || y < 0.0 || z < 0.0 {
+            return Err(Error::ErrorString(
+                "XYZ values should be all positive values".into(),
+            ));
+        }
+        Ok(XYZ::from_vecs(Vector3::new(x, y, z), obs))
+    }
+
+    /// Get the XYZ tristimulus value as an array.
+    #[wasm_bindgen(js_name=values)]
+    pub fn values_js(&self) -> js_sys::Array {
+        let &[x, y, z] = self.xyz.as_ref();
+        js_sys::Array::of3(&x.into(), &y.into(), &z.into())
+    }
+
+    /// Get the chromaticity coordinates
+    #[wasm_bindgen(js_name=chromaticity)]
+    pub fn chromaticity_js(&self) -> js_sys::Array {
+        let [x, y] = self.chromaticity().to_array();
+        js_sys::Array::of2(&x.into(), &y.into())
+    }
+
+    /// Get the luminous value, Y.
+    #[wasm_bindgen(js_name=y)]
+    pub fn y_js(&self) -> f64 {
+        self.y()
+    }
+}


### PR DESCRIPTION
This moves wasm specific code to their own modules and makes all wasm related code conditionally compiled behind cfg gates for that target. This allows us to build the library on non-wasm targets without depending on `js-sys` and `wasm-bindgen`. This brings down the dependency tree size for users who don't use this library as wasm.

I think the moving of wasm specific code into their own modules is good for structure as well. I'm not trying to make wasm a lower priority here. Quite the opposite. By letting it have their own modules it becomes easier to get an overview of the JS-API as well as extend it IMO.

I also updated some documentation, since it was very outdated for certain `*_js` methods.